### PR TITLE
Implement external data packaging capability

### DIFF
--- a/app/quilt_mcp/tools/package_management.py
+++ b/app/quilt_mcp/tools/package_management.py
@@ -25,7 +25,8 @@ def create_package_enhanced(
     metadata: Any = None,
     registry: Optional[str] = None,
     dry_run: bool = False,
-    auto_organize: bool = True
+    auto_organize: bool = True,
+    copy_mode: str = "all",
 ) -> Dict[str, Any]:
     """
     Enhanced package creation with better error handling and metadata templates.
@@ -217,7 +218,8 @@ def create_package_enhanced(
                 s3_uris=files,
                 registry=registry,
                 metadata=template_metadata,
-                message=f"Created via enhanced package creation: {description}" if description else "Created via enhanced package creation"
+                message=f"Created via enhanced package creation: {description}" if description else "Created via enhanced package creation",
+                copy_mode=copy_mode,
             )
             
             # Enhance the result with additional information

--- a/app/quilt_mcp/tools/unified_package.py
+++ b/app/quilt_mcp/tools/unified_package.py
@@ -24,7 +24,8 @@ def create_package(
     auto_organize: bool = True,
     dry_run: bool = False,
     target_registry: Optional[str] = None,
-    metadata: Any = None
+    metadata: Any = None,
+    copy_mode: str = "all",
 ) -> Dict[str, Any]:
     """
     Unified package creation tool that handles everything automatically.
@@ -119,7 +120,8 @@ def create_package(
                 auto_organize=auto_organize,
                 dry_run=dry_run,
                 target_registry=target_registry,
-                metadata=processed_metadata
+                metadata=processed_metadata,
+                copy_mode=copy_mode,
             )
         elif file_analysis["source_type"] == "local_only":
             return _create_package_from_local_sources(
@@ -431,7 +433,8 @@ def _create_package_from_s3_sources(
     auto_organize: bool,
     dry_run: bool,
     target_registry: Optional[str],
-    metadata: Optional[Dict[str, Any]]
+    metadata: Optional[Dict[str, Any]],
+    copy_mode: str,
 ) -> Dict[str, Any]:
     """Create package from S3 sources using enhanced S3-to-package tool."""
     try:
@@ -458,7 +461,8 @@ def _create_package_from_s3_sources(
             description=description,
             auto_organize=auto_organize,
             dry_run=dry_run,
-            metadata=metadata
+            metadata=metadata,
+            copy_mode=copy_mode,
         )
         
         # Enhance the result with unified package creation context

--- a/app/tests/test_selector_fn.py
+++ b/app/tests/test_selector_fn.py
@@ -1,0 +1,101 @@
+import pytest
+from unittest.mock import patch
+
+from quilt_mcp.tools.package_ops import package_create
+from quilt_mcp.tools.s3_package import package_create_from_s3
+
+
+def _make_push_assertions(expected_behaviors):
+    """
+    Build a replacement for quilt3.Package.push that asserts selector_fn decisions.
+
+    expected_behaviors: list of tuples (logical_key, expect_true)
+    """
+
+    def _push(self, name, registry=None, message=None, selector_fn=None, **kwargs):  # type: ignore[no-redef]
+        assert callable(selector_fn)
+        for logical_key, expect in expected_behaviors:
+            entry = self[logical_key]
+            assert bool(selector_fn(logical_key, entry)) is expect
+        return "test_top_hash"
+
+    return _push
+
+
+@patch("quilt3.Package.push")
+def test_package_ops_copy_mode_none(mock_push):
+    # Configure mock to assert selector always False
+    mock_push.side_effect = _make_push_assertions([
+        ("file1.csv", False),
+        ("file2.json", False),
+    ])
+
+    result = package_create(
+        package_name="team/pkg",
+        s3_uris=[
+            "s3://bucket-a/dir/file1.csv",
+            "s3://bucket-b/file2.json",
+        ],
+        registry="s3://target-bucket",
+        copy_mode="none",
+        flatten=True,
+    )
+
+    assert result.get("status") == "success"
+    assert result.get("top_hash") == "test_top_hash"
+
+
+@patch("quilt3.Package.push")
+def test_package_ops_copy_mode_same_bucket(mock_push):
+    # One file in target bucket should be True, other should be False
+    mock_push.side_effect = _make_push_assertions([
+        ("file1.csv", True),   # s3://target-bucket/...
+        ("file2.json", False), # s3://other-bucket/...
+    ])
+
+    result = package_create(
+        package_name="team/pkg",
+        s3_uris=[
+            "s3://target-bucket/path/file1.csv",
+            "s3://other-bucket/file2.json",
+        ],
+        registry="s3://target-bucket",
+        copy_mode="same_bucket",
+        flatten=True,
+    )
+
+    assert result.get("status") == "success"
+    assert result.get("top_hash") == "test_top_hash"
+
+
+@patch("quilt3.Package.push")
+@patch("quilt_mcp.tools.s3_package._discover_s3_objects")
+@patch("quilt_mcp.tools.s3_package._validate_bucket_access")
+@patch("quilt_mcp.tools.s3_package.bucket_access_check")
+def test_s3_package_copy_mode_none(mock_access_check, mock_validate, mock_discover, mock_push):
+    # Simulate write access to target registry
+    mock_access_check.return_value = {"success": True, "access_summary": {"can_write": True}}
+    mock_validate.return_value = None
+    mock_discover.return_value = [
+        {"Key": "data/file1.csv", "Size": 100},
+        {"Key": "data/file2.csv", "Size": 200},
+    ]
+
+    # In enhanced creator, logical keys will be folder/name
+    mock_push.side_effect = _make_push_assertions([
+        ("data/processed/file1.csv", False),
+        ("data/processed/file2.csv", False),
+    ])
+
+    result = package_create_from_s3(
+        source_bucket="source-bucket",
+        package_name="team/pkg",
+        target_registry="s3://target-bucket",
+        copy_mode="none",
+        auto_organize=True,
+        description="test",
+    )
+
+    assert result.get("success") is True
+    assert result.get("package_hash") == "test_top_hash"
+


### PR DESCRIPTION
Add `copy_mode` to package creation tools to control copying vs. referencing external S3 data.

This implements the `selector_fn` capability, allowing users to create packages that point to data in other buckets without copying it, or to selectively copy data based on its location relative to the target registry.

---
<a href="https://cursor.com/background-agent?bcId=bc-4ae78c79-f180-4663-857b-e097fe272fbe">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4ae78c79-f180-4663-857b-e097fe272fbe">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

