### PR TITLE
Add make kill target to stop running MCP servers

### DIFF
--- a/make.dev
+++ b/make.dev
@@ -8,7 +8,7 @@ export
 # Development endpoint configuration
 DEV_ENDPOINT ?= http://127.0.0.1:8001/mcp/
 
-.PHONY: test test-unit test-integration test-ci lint coverage run run-inspector dev-clean
+.PHONY: test test-unit test-integration test-ci lint coverage run run-inspector kill dev-clean
 
 # Test Targets
 test:
@@ -68,6 +68,15 @@ run-inspector:
 	@echo "Starting MCP Inspector with server at $(DEV_ENDPOINT)"
 	@echo "Inspector UI will be available at http://127.0.0.1:6274"
 	@export PYTHONPATH="src" && npx @modelcontextprotocol/inspector uv run python src/main.py
+
+kill:
+	@echo "Killing running MCP server processes..."
+	@pkill -f "python.*main.py" 2>/dev/null || echo "No main.py processes found"
+	@pkill -f "python.*quilt_mcp" 2>/dev/null || echo "No quilt_mcp processes found" 
+	@pkill -f "@modelcontextprotocol/inspector" 2>/dev/null || echo "No MCP Inspector processes found"
+	@lsof -ti :8000 | xargs -r kill 2>/dev/null || echo "No processes on port 8000"
+	@lsof -ti :8001 | xargs -r kill 2>/dev/null || echo "No processes on port 8001"
+	@echo "✅ Server kill completed"
 
 # Cleanup Targets
 dev-clean:


### PR DESCRIPTION
## Summary
- Add comprehensive `make kill` target to stop running MCP server processes
- Resolves "address already in use" errors by cleaning up stale processes
- Handles multiple process types and port conflicts

## Changes
- **New target**: `make kill` in `make.dev` 
- **Process cleanup**: Kills Python main.py, quilt_mcp, and MCP Inspector processes
- **Port cleanup**: Kills processes using ports 8000 and 8001
- **Error handling**: Graceful fallbacks when no processes found

## Test Plan
- [x] Tested killing stale server process (PID 57594) that was blocking port 8000
- [x] Verified server can start cleanly after kill
- [x] Confirmed graceful shutdown with SIGTERM
- [x] Validated error handling when no processes found

## Usage
```bash
make kill  # Stop all running MCP servers
make run   # Start fresh server without port conflicts
```

🤖 Generated with [Claude Code](https://claude.ai/code)