### PR TITLE
Fix: Make CI Python tests run serially

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ jobs:
     timeout-minutes: 30
     strategy:
       fail-fast: false
+      max-parallel: 1
       matrix:
         python-version: ["3.11", "3.12", "3.13"]
     


### PR DESCRIPTION
## Summary
- Add `max-parallel: 1` to CI matrix strategy to prevent Python version tests from running in parallel
- Resolves resource contention issues that were causing CI to choke

## Changes
- Modified `.github/workflows/ci.yml` to run Python 3.11, 3.12, and 3.13 tests sequentially
- Maintains clean matrix configuration while eliminating parallel execution conflicts

## Test plan
- [x] CI will test the change automatically on this PR
- Verify tests run serially without resource conflicts

🤖 Generated with [Claude Code](https://claude.ai/code)