### PR TITLE
fix: Re-enable bucket_objects_list tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.6.4] - UNRELEASED
 
-- **Tool Exclusion System**
-  - Re-enabled `bucket_objects_list`
+### Tool Management
+
+- **Tool Re-enablement**: Re-enabled `bucket_objects_list` tool
+  - Removed from excluded tools list to restore client access
+  - Tool remains fully functional for bucket object listing operations
 
 ### Enhanced Athena Workgroups Management
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.6.4] - UNRELEASED
 
+- **Tool Exclusion System**
+  - Re-enabled `bucket_objects_list`
+
 ### Enhanced Athena Workgroups Management
 
 - **Enhanced Athena Workgroups Listing**: Complete redesign of `athena_workgroups_list` functionality (#133)

--- a/src/quilt_mcp/utils.py
+++ b/src/quilt_mcp/utils.py
@@ -106,8 +106,7 @@ def register_tools(mcp: FastMCP, tool_modules: list[Any] | None = None, verbose:
 
     # List of deprecated tools (to reduce client confusion)
     excluded_tools = {
-        "packages_list",  # Prefer packages_search
-        "bucket_objects_list",  # Prefer bucket_objects_search
+        "packages_list"  # Prefer packages_search
     }
 
     tools_registered = 0


### PR DESCRIPTION
## Summary
- Re-enabled `bucket_objects_list` tool by removing it from the excluded tools list
- Updated CHANGELOG.md to document the change

## Test plan
- [x] Verify tool is no longer excluded from registration
- [x] Confirm tool functionality remains intact
- [x] Update documentation in CHANGELOG.md

🤖 Generated with [Claude Code](https://claude.ai/code)