### PR TITLE
fix: correct coverage file paths in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
           uv sync --group test
           mkdir -p build/test-results
           export PYTHONPATH="src" && QUILT_DISABLE_QUILT3_SESSION=1 uv run python -m pytest tests/ -v -m "not search" --timeout=${PYTEST_TIMEOUT:-120} --disable-warnings \
-            --junitxml=build/test-results/results.xml --cov=quilt_mcp --cov-report=xml:src/coverage.xml
+            --junitxml=build/test-results/results.xml --cov=quilt_mcp --cov-report=xml:build/test-results/coverage.xml
         else
           echo "Running CI tests (skipping slow tests) for Python ${{ matrix.python-version }}..."
           make test-ci
@@ -57,9 +57,7 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: test-results-py${{ matrix.python-version }}
-        path: |
-          build/test-results/
-          src/coverage.xml
+        path: build/test-results/
         retention-days: 7
 
   build-and-release:

--- a/make.dev
+++ b/make.dev
@@ -38,7 +38,7 @@ test-ci:
 	@uv sync --group test
 	@mkdir -p build/test-results
 	@export PYTHONPATH="src" && QUILT_DISABLE_QUILT3_SESSION=1 uv run python -m pytest tests/ -v -m "not search and not slow" --timeout=$${PYTEST_TIMEOUT:-120} --disable-warnings \
-		--junitxml=build/test-results/results.xml --cov=quilt_mcp --cov-report=xml:src/coverage.xml
+		--junitxml=build/test-results/results.xml --cov=quilt_mcp --cov-report=xml:build/test-results/coverage.xml
 
 # Code Quality Targets
 lint:

--- a/uv.lock
+++ b/uv.lock
@@ -1900,7 +1900,7 @@ wheels = [
 
 [[package]]
 name = "quilt-mcp-server"
-version = "0.6.5"
+version = "0.6.6"
 source = { editable = "." }
 dependencies = [
     { name = "altair" },


### PR DESCRIPTION
Fixes the issue where coverage XML files weren't being included in CI artifacts.

## Changes
- Updated CI workflow to generate coverage at `build/test-results/coverage.xml`  
- Updated `make test-ci` target to use the same path
- Simplified artifact upload to include entire `build/test-results/` directory

## Testing
- [x] Verified coverage file generation works locally
- [x] Coverage XML now appears in correct location

This should fix the missing coverage artifacts in GitHub Actions runs.