### PR TITLE
Phase 2: python publish design

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,7 @@ help:
 	@echo "  make deploy-build     - Prepare production build environment"
 	@echo "  make dxt              - Create DXT package"
 	@echo "  make python-dist      - Build wheel + sdist into dist/ using uv (no publish)"
+	@echo "  make python-publish   - Publish dist/ artifacts via uv (requires credentials)"
 	@echo "  make dxt-validate     - Validate DXT package"
 	@echo "  make release-zip      - Create release bundle with documentation"
 	@echo "  make release          - Create and push release tag"

--- a/bin/release.sh
+++ b/bin/release.sh
@@ -107,9 +107,38 @@ python_publish() {
         return 0
     fi
 
-    echo "📦 Publishing artifacts from $dist_dir to $publish_url"
+    echo "📦 Publishing artifacts from $dist_dir to ${publish_url:-https://test.pypi.org/legacy/}"
     "${publish_cmd[@]}"
     echo "✅ python-publish completed"
+
+    local package_name
+    package_name=$(python3 - <<'PY'
+import tomllib
+with open('pyproject.toml', 'rb') as f:
+    data = tomllib.load(f)
+print(data["project"]["name"])
+PY
+)
+
+    local package_version
+    package_version=$(python3 - <<'PY'
+import tomllib
+with open('pyproject.toml', 'rb') as f:
+    data = tomllib.load(f)
+print(data["project"]["version"])
+PY
+)
+
+    local project_url=""
+    if [[ "${publish_url:-https://test.pypi.org/legacy/}" == *"test.pypi.org"* ]]; then
+        project_url="https://test.pypi.org/project/${package_name}/${package_version}/"
+    elif [[ "${publish_url}" == *"pypi.org"* ]]; then
+        project_url="https://pypi.org/project/${package_name}/${package_version}/"
+    fi
+
+    if [ -n "$project_url" ]; then
+        echo "🔗 View package at $project_url"
+    fi
 }
 
 check_clean_repo() {

--- a/env.example
+++ b/env.example
@@ -22,3 +22,16 @@ FASTMCP_TRANSPORT=stdio
 
 # ngrok Configuration for remote tunneling (optional)
 NGROK_DOMAIN=my-free-domain.ngrok-free.app
+
+# Python packaging (uv)
+# Required for publishing: set either UV_PUBLISH_TOKEN or both UV_PUBLISH_USERNAME/UV_PUBLISH_PASSWORD.
+# Leave unset to build locally without publishing.
+UV_PUBLISH_TOKEN=your-testpypi-token
+UV_PUBLISH_USERNAME=testpypi-username
+UV_PUBLISH_PASSWORD=testpypi-password
+
+# Optional: Override publish endpoint (defaults to TestPyPI)
+PYPI_PUBLISH_URL=https://test.pypi.org/legacy/
+
+# Optional: Override dist output directory (defaults to dist/)
+DIST_DIR=dist

--- a/make.deploy
+++ b/make.deploy
@@ -26,7 +26,7 @@ DEPS_MARKER := $(BUILD_DIR)/.deps-installed
 ASSET_FILES := $(wildcard $(ASSETS_DIR)/*)
 APP_FILES := $(shell find $(APP_DIR)/quilt_mcp -name "*.py" 2>/dev/null || true)
 
-.PHONY: deploy-build dxt dxt-validate python-dist release-zip deploy-clean check-tools
+.PHONY: deploy-build dxt dxt-validate python-dist python-publish release-zip deploy-clean check-tools
 
 # Check for required tools
 check-tools:
@@ -89,6 +89,9 @@ dxt: $(DXT_PACKAGE)
 
 python-dist:
 	@./bin/release.sh python-dist
+
+python-publish:
+	@./bin/release.sh python-publish
 
 # DXT Package Validation
 dxt-validate: check-tools dxt

--- a/spec/2025-09-20-uv-package/09-phase2-design.md
+++ b/spec/2025-09-20-uv-package/09-phase2-design.md
@@ -18,12 +18,12 @@
 ## Implementation Outline
 1. **Environment Handling**
    - Helper `ensure_publish_env` checks for token or username/password.
-   - Accept optional `PYPI_REPOSITORY_URL` (default `https://test.pypi.org/legacy/`).
+   - Accept optional `PYPI_PUBLISH_URL` (default `https://test.pypi.org/legacy/`).
    - Validate dist artifacts exist before publishing.
 
 2. **Script Command**
    - Add `python-publish` subcommand to `bin/release.sh`.
-   - Build uv command: `uv publish --repository-url $PYPI_REPOSITORY_URL` with auth flags.
+   - Build uv command: `uv publish --publish-url $PYPI_PUBLISH_URL dist/*` with appropriate auth flags.
    - In dry run, echo command without secrets; in real run, invoke uv with env vars.
 
 3. **Make Integration**

--- a/spec/2025-09-20-uv-package/09-phase2-design.md
+++ b/spec/2025-09-20-uv-package/09-phase2-design.md
@@ -1,0 +1,54 @@
+<!-- markdownlint-disable MD013 MD025 -->
+# Phase 2 Design – Python Publish Workflow
+
+## Objectives
+- Introduce a `python-publish` command in `bin/release.sh` that drives `uv publish` to TestPyPI/PyPI.
+- Require explicit credentials (token or username/password) and fail fast when they are missing.
+- Support dry runs locally by logging the intended publish command without executing it.
+- Provide a make target wrapper so developers can invoke publishes consistently.
+- Document `.env` expectations and dry-run instructions for TestPyPI.
+
+## Scope & Constraints
+- Command must reuse the artifacts produced by `python-dist`; no rebuilds.
+- Credential handling must avoid printing secrets to stdout.
+- Support token-based auth (`UV_PUBLISH_TOKEN`) and basic auth (`UV_PUBLISH_USERNAME`/`UV_PUBLISH_PASSWORD`).
+- Allow overriding repository URL via env (default to TestPyPI for dry runs).
+- Dry-run mode (`DRY_RUN=1`) must never execute the real publish.
+
+## Implementation Outline
+1. **Environment Handling**
+   - Helper `ensure_publish_env` checks for token or username/password.
+   - Accept optional `PYPI_REPOSITORY_URL` (default `https://test.pypi.org/legacy/`).
+   - Validate dist artifacts exist before publishing.
+
+2. **Script Command**
+   - Add `python-publish` subcommand to `bin/release.sh`.
+   - Build uv command: `uv publish --repository-url $PYPI_REPOSITORY_URL` with auth flags.
+   - In dry run, echo command without secrets; in real run, invoke uv with env vars.
+
+3. **Make Integration**
+   - Add `make python-publish` target delegating to `release.sh python-publish`.
+   - Document in Makefile help alongside `python-dist`.
+
+4. **Testing Strategy**
+   - Pytest covering:
+     - Failure when credentials missing.
+     - Success path in dry-run with token env; assert command logged without secret leak.
+     - Make target delegates to script.
+   - Use temp dist dir with fake artifact file to satisfy preflight.
+
+5. **Documentation**
+   - Update CLAUDE.md with `.env` keys and dry-run instructions.
+   - Outline sample `.env` entries for TestPyPI (username/password or token).
+
+## Open Decisions
+- Whether to support repository alias (prod vs test) via CLI flag.
+- Naming of env var for repository; defaulting to TestPyPI but allow override.
+
+## Testing Matrix
+| Scenario | Credentials | DRY_RUN | Repo | Expected |
+| --- | --- | --- | --- | --- |
+| Missing env | none | 1 | default | Fails fast with helpful error |
+| Token dry run | token | 1 | test | Logs command, no publish |
+| User/pass dry run | user/pass | 1 | test | Logs command, no publish |
+| Real publish (manual) | token | 0 | test/prod | Uses uv publish; manual verification |

--- a/spec/2025-09-20-uv-package/10-phase2-episodes.md
+++ b/spec/2025-09-20-uv-package/10-phase2-episodes.md
@@ -1,0 +1,13 @@
+<!-- markdownlint-disable MD013 MD025 -->
+# Phase 2 Episodes – Python Publish Workflow
+
+1. **Failing Tests for Publish Guardrails**
+   - Add pytest cases verifying `python-publish` fails without credentials, succeeds in dry-run with token/user-pass, and requires dist artifacts.
+2. **Implement Publish Command**
+   - Add `ensure_publish_env`, `python-publish` subcommand, repository handling, and dry-run logging to `bin/release.sh`.
+3. **Make Target & Docs**
+   - Add `make python-publish`, update Makefile help, and extend CLAUDE.md with `.env` guidance and dry-run walkthrough.
+4. **Validation & Cleanup**
+   - Run targeted pytest + `make test-unit`, ensure dist temp dirs cleaned, and update PR notes.
+
+Each episode should maintain green state outside the current Red/Green loop.

--- a/spec/2025-09-20-uv-package/11-phase2-checklist.md
+++ b/spec/2025-09-20-uv-package/11-phase2-checklist.md
@@ -1,0 +1,23 @@
+<!-- markdownlint-disable MD013 MD025 -->
+# Phase 2 Checklist – Python Publish Workflow
+
+## Preconditions
+- [ ] Branch `phase2-python-publish` checked out and up to date.
+- [ ] `uv` CLI available.
+- [ ] TestPyPI credentials accessible for validation (token or username/password).
+
+## Development Steps
+- [ ] Red: add failing tests covering `bin/release.sh python-publish` behaviors.
+- [ ] Green: implement publish command, env validation, repository handling, and make target.
+- [ ] Documentation: update CLAUDE.md with `.env` keys and dry-run instructions.
+- [ ] Ensure no secrets are logged; scrub outputs in tests.
+
+## Validation
+- [ ] Targeted pytest module passes (`tests/unit/test_release_uv.py`).
+- [ ] `make test-unit` passes.
+- [ ] Dry-run manual invocation logs expected command.
+- [ ] Update PR description and notes.
+
+## Postconditions
+- [ ] `python-dist` + `python-publish` flow documented and test-covered.
+- [ ] Ready to plan Phase 3 (CI Trusted Publishing integration).

--- a/tests/unit/test_release_uv.py
+++ b/tests/unit/test_release_uv.py
@@ -65,3 +65,75 @@ def test_make_python_dist_delegates_to_release(tmp_path):
     assert proc.returncode == 0
     assert "python-dist" in proc.stdout
     assert Path(env["DIST_DIR"]).exists()
+
+
+@pytest.mark.usefixtures("monkeypatch")
+def test_python_publish_requires_credentials(tmp_path):
+    env = os.environ.copy()
+    for key in ["UV_PUBLISH_TOKEN", "UV_PUBLISH_USERNAME", "UV_PUBLISH_PASSWORD"]:
+        env.pop(key, None)
+    dist_dir = tmp_path / "dist"
+    dist_dir.mkdir()
+    (dist_dir / "dummy.whl").write_text("fake")
+    env["DIST_DIR"] = str(dist_dir)
+    env["DRY_RUN"] = "1"
+
+    proc = subprocess.run(
+        [str(RELEASE_SCRIPT), "python-publish"],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+    assert proc.returncode != 0
+    assert "Missing publish credentials" in proc.stdout
+
+
+@pytest.mark.usefixtures("monkeypatch")
+def test_python_publish_dry_run_with_token(tmp_path):
+    env = os.environ.copy()
+    env["UV_PUBLISH_TOKEN"] = "token-value"
+    env["DRY_RUN"] = "1"
+    dist_dir = tmp_path / "dist"
+    dist_dir.mkdir()
+    (dist_dir / "dummy.whl").write_text("fake")
+    env["DIST_DIR"] = str(dist_dir)
+    env["PYPI_REPOSITORY_URL"] = "https://test.pypi.org/legacy/"
+
+    proc = subprocess.run(
+        [str(RELEASE_SCRIPT), "python-publish"],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+    assert proc.returncode == 0
+    assert "uv publish" in proc.stdout
+    assert "token-value" not in proc.stdout
+
+
+@pytest.mark.usefixtures("monkeypatch")
+def test_make_python_publish_delegates(tmp_path):
+    env = os.environ.copy()
+    env["UV_PUBLISH_USERNAME"] = "user"
+    env["UV_PUBLISH_PASSWORD"] = "pass"
+    env["DRY_RUN"] = "1"
+    dist_dir = tmp_path / "dist"
+    dist_dir.mkdir()
+    (dist_dir / "dummy.tar.gz").write_text("fake")
+    env["DIST_DIR"] = str(dist_dir)
+
+    make_args = ["make", f"DIST_DIR={env['DIST_DIR']}", "python-publish"]
+
+    proc = subprocess.run(
+        make_args,
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+    assert proc.returncode == 0
+    assert "python-publish" in proc.stdout

--- a/tests/unit/test_release_uv.py
+++ b/tests/unit/test_release_uv.py
@@ -111,6 +111,7 @@ def test_python_publish_dry_run_with_token(tmp_path):
 
     assert proc.returncode == 0
     assert "uv publish" in proc.stdout
+    assert "--publish-url https://test.pypi.org/legacy/" in proc.stdout
     assert "token-value" not in proc.stdout
 
 
@@ -137,3 +138,6 @@ def test_make_python_publish_delegates(tmp_path):
 
     assert proc.returncode == 0
     assert "python-publish" in proc.stdout
+    assert "--password ****" in proc.stdout
+    password_segment = proc.stdout.split("--password ", 1)[1]
+    assert "pass" not in password_segment


### PR DESCRIPTION
## Summary
- add Phase 2 design/episodes/checklist files covering python publish workflow
- implement `bin/release.sh python-publish` with credential validation, repository overrides, and make target wrapper
- document `.env` expectations and extend tests to cover publish path

## Testing
- PYTHONPATH=src uv run pytest tests/unit/test_release_uv.py -k publish -v
- make test-unit
