### PR TITLE
spec: plan uv trusted publishing rollout

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -407,8 +407,8 @@ The following permissions are granted for this repository:
 - Workflow orchestration APIs reject blank workflow IDs; trim identifiers in tests when constructing fixtures to avoid silent acceptance.
 
 ### 2025-09-20 uv packaging notes
-- DXT packaging currently runs through `make.deploy` using `uv pip install`; the UV PyPI build flow is centralized in `bin/release.sh python-dist` with a `make python-dist` wrapper, mirroring how `make dxt` exposes DXT packaging.
-- `python-dist` only builds local artifacts—no credentials required. A future `bin/release.sh python-publish` will enforce `UV_PUBLISH_TOKEN` or username/password before pushing to PyPI/TestPyPI.
+- DXT packaging currently runs through `make.deploy` using `uv pip install`; the UV PyPI build flow lives in `bin/release.sh python-dist` with `make python-dist`, mirroring how `make dxt` exposes DXT packaging.
+- `python-dist` builds local artifacts without credentials. `bin/release.sh python-publish` (via `make python-publish`) requires either `UV_PUBLISH_TOKEN` or `UV_PUBLISH_USERNAME`/`UV_PUBLISH_PASSWORD`, defaults to TestPyPI (`PYPI_REPOSITORY_URL` override), and respects `DIST_DIR`.
 
 ## important-instruction-reminders
 

--- a/spec/2025-09-20-uv-package/04-phases.md
+++ b/spec/2025-09-20-uv-package/04-phases.md
@@ -33,18 +33,18 @@
 
 ## Phase 3 – GitHub Trusted Publishing Integration
 
-- **Goal**: Automate production publishing via GitHub Actions using Trusted Publishing on tag push, delegating to `release.sh python-publish`.
+- **Goal**: Automate production publishing via GitHub Actions using Trusted Publishing on tag push, delegating to `release.sh` so DXT and Python artifacts are handled together.
 - **Deliverables**:
-  - Workflow YAML that calls `release.sh python-dist` then `release.sh python-publish` under Trusted Publishing.
-  - Release documentation noting tag-driven publish process and credential separation.
-  - Safeguards ensuring DXT workflow remains unaffected (separate jobs or conditionals).
+  - Workflow YAML that invokes the release entry point (`release.sh release` or equivalent) which now runs DXT packaging, `python-dist`, and `python-publish` in sequence under Trusted Publishing.
+  - Release documentation noting tag-driven publish process, credential separation, and dual-artifact output.
+  - Safeguards ensuring combined flow still preserves legacy DXT behaviour for other callers.
 - **Validation**:
-  - Workflow dry run or manual approval confirming Trusted Publishing handshake.
-  - Tag-triggered build completes without manual secrets.
+  - Workflow dry run or manual approval confirming Trusted Publishing handshake and dist publishing.
+  - Tag-triggered build completes without manual secrets while producing both DXT and Python artifacts.
 
 # Cross-Phase Considerations
 
 1. Ensure environment validation logic lives in the publish path, keeping local build command credential-free while CI and publish flows remain consistent.
 2. Each phase should run the existing test suite to maintain safety net coverage.
-3. Communicate rollout plan so maintainers know when to use DXT vs uv packaging.
+3. Communicate rollout plan so maintainers know the release script now emits both DXT and Python artifacts while standalone targets remain available for focused workflows.
 4. Track external dependencies (GitHub settings) as risks if they cannot be completed within the repo.

--- a/spec/2025-09-20-uv-package/12-phase3-design.md
+++ b/spec/2025-09-20-uv-package/12-phase3-design.md
@@ -1,0 +1,51 @@
+<!-- markdownlint-disable MD013 MD025 -->
+# Phase 3 Design – Trusted Publishing & Combined Release Flow
+
+## Objectives
+- Extend `bin/release.sh` so the production release path builds DXT artifacts, builds Python distributions, and publishes them via `uv publish` in a single orchestrated command.
+- Ensure GitHub Actions Trusted Publishing jobs reuse the same release script entry point, eliminating divergence between local dry runs and CI execution.
+- Keep existing tagging commands and DXT tooling functional while layering Python packaging on top.
+
+## Scope & Constraints
+- Continue to treat DXT packaging as a first-class deliverable; Python builds must not skip or replace existing bundle generation.
+- `python-dist` and `python-publish` remain reusable standalone commands; the combined release flow composes them but does not duplicate logic.
+- CI must rely on Trusted Publishing (OIDC) without storing TestPyPI or PyPI credentials; local dry runs still require `.env` secrets.
+- Maintain `DRY_RUN` semantics across the orchestrated release path so tests and previews avoid mutating state.
+- Avoid introducing dependencies outside approved toolchain (bash, make, uv, existing Node tooling for DXT).
+
+## Implementation Outline
+1. **Release Script Orchestration**
+   - Add a helper (e.g., `run_release_artifacts`) that sequentially invokes:
+     1. `make dxt` and `make dxt-validate` (or equivalent shell helpers) to preserve existing bundle workflow.
+     2. `python_dist` function to build wheel and sdist artifacts into `dist/`.
+     3. `python_publish` function to publish previously built artifacts.
+   - Introduce a new subcommand (placeholder name: `ci-release`) that calls the helper and exits on failure; expose `--dry-run` passthrough.
+   - Update user-facing `release` command to optionally call the helper when invoked with a flag (e.g., `release --with-artifacts`) so maintainers can execute the combined flow locally before tagging.
+   - Ensure `DIST_DIR` and DXT directories coexist without clobbering; surface summary output listing both DXT and Python artifacts.
+
+2. **Environment Handling**
+   - Extend `python_publish` to detect Trusted Publishing context: prefer `UV_PUBLISH_TOKEN` or fall back to GitHub-provided token/oidc integration if present.
+   - Continue to require credentials locally; log actionable guidance when running in CI without required env (expected to be handled by workflow secrets/permissions).
+
+3. **GitHub Actions Integration**
+   - Update `.github/actions/create-release/action.yml` (or equivalent workflow step) to call `./bin/release.sh ci-release` instead of raw make targets, ensuring DXT + Python releases occur together.
+   - Provide environment configuration in the workflow step (e.g., `UV_PUBLISH_TOKEN`, `PYPI_PUBLISH_URL`, OIDC permissions) and upload Python artifacts alongside DXT bundles where appropriate.
+   - Record outputs (e.g., distribution paths or package URLs) for release notes if needed.
+
+4. **Documentation & Developer Workflow**
+   - Refresh release documentation to explain the combined flow, noting that `release.sh` orchestrates both artifact families.
+   - Highlight dry-run usage (`DRY_RUN=1 ./bin/release.sh ci-release`) for developers verifying the pipeline without pushing tags.
+
+## Open Decisions
+- Exact naming for the new subcommand (`ci-release`, `release-artifacts`, etc.) and whether it should be callable from make (`make release-python`?).
+- Where to surface Python artifact uploads in GitHub Releases (attach wheels/sdists or rely solely on PyPI links).
+- Whether to gate `python_publish` within CI behind a conditional to allow tag-only dry runs (e.g., skip publish on non-production tags).
+
+## Testing Matrix
+| Scenario | Context | DRY_RUN | Expected Outcome |
+| --- | --- | --- | --- |
+| Local dry run | Developer machine | 1 | Logs sequential DXT build, dist build, publish command without executing heavy steps |
+| Missing dist artifacts | CI or local | 0 | Combined command fails after `python_dist` if artifacts absent, surfacing actionable error |
+| Trusted Publishing run | GitHub Actions | 0 | Generates DXT + Python artifacts, publishes via uv, exits success |
+| Standalone commands | Developer machine | 0 | `python-dist` / `python-publish` still function independently |
+| Legacy release tag | Developer machine | 0 | `release.sh release` without flag behaves as today (tag only) |

--- a/spec/2025-09-20-uv-package/13-phase3-episodes.md
+++ b/spec/2025-09-20-uv-package/13-phase3-episodes.md
@@ -1,0 +1,26 @@
+<!-- markdownlint-disable MD013 MD025 -->
+# Phase 3 Episodes – Trusted Publishing Rollout
+
+## Episode 1 – Spec-Driven Tests for Combined Release Flow
+- Add pytest coverage that executes `./bin/release.sh ci-release --dry-run` (name TBD) and asserts ordered logging for DXT build, Python dist build, and publish preview.
+- Extend tests ensuring failure propagation when `python-publish` preconditions are unmet (e.g., missing credentials in non-dry-run mode).
+- Capture fixtures for Trusted Publishing env simulation (OIDC tokens mocked via env vars).
+
+## Episode 2 – Implement Release Script Orchestration
+- Introduce helper that composes `make dxt`, `make dxt-validate`, `python_dist`, and `python_publish` with shared `DRY_RUN` handling.
+- Add new subcommand wiring (plus optional flag for `release --with-artifacts`) while keeping legacy behaviour untouched.
+- Ensure summary output surfaces both artifact families.
+
+## Episode 3 – Update GitHub Actions Pipeline
+- Modify `.github/actions/create-release` to call the new release script subcommand.
+- Configure workflow permissions and environment for Trusted Publishing (OIDC token, `UV_PUBLISH_TOKEN` or equivalent).
+- Upload Python artifacts (or log PyPI URLs) alongside existing DXT assets.
+
+## Episode 4 – Documentation Refresh
+- Update release sections in CLAUDE.md (and any workflow docs) to explain the unified release script usage.
+- Document dry-run expectations and how CI now leverages `release.sh` for both artifact families.
+
+## Episode 5 – Verification & Hardening
+- Run `make test` and targeted smoke tests for the new release command in dry-run mode.
+- Perform end-to-end rehearsal (manual or scripted) to confirm dual artifact generation and publishing succeed under DRY_RUN=0 with test credentials.
+- Record lessons learned in CLAUDE.md per repository guidelines.

--- a/spec/2025-09-20-uv-package/14-phase3-checklist.md
+++ b/spec/2025-09-20-uv-package/14-phase3-checklist.md
@@ -1,0 +1,11 @@
+<!-- markdownlint-disable MD013 MD025 -->
+# Phase 3 Checklist – Trusted Publishing Integration
+
+- [ ] Write failing tests covering the combined release subcommand dry run and error propagation.
+- [ ] Implement release script orchestration that runs DXT build/validate, `python-dist`, and `python-publish` sequentially with shared `DRY_RUN` logic.
+- [ ] Ensure standalone `python-dist` / `python-publish` commands remain functional and documented.
+- [ ] Update GitHub Actions workflow to invoke the new release script entry point with Trusted Publishing permissions.
+- [ ] Upload or reference Python artifacts in the GitHub Release alongside existing DXT bundles.
+- [ ] Refresh documentation (CLAUDE.md, release sections) describing the unified release flow and dry-run guidance.
+- [ ] Execute `make test` plus targeted dry-run of the combined release command.
+- [ ] Record insights in CLAUDE.md per repository guidelines after implementation.


### PR DESCRIPTION
## Summary
- document Phase 3 objectives focusing on combined DXT + Python release flow
- lay out episode plan and checklist for implementing trusted publishing orchestration
- align overall spec with single-entry release script expectations

## Testing
- not run (spec updates only)