### PR TITLE
feat: Add automatic README.md and quilt_summarize.json generation to packages

### DIFF
--- a/src/quilt_mcp/services/readme_generator.py
+++ b/src/quilt_mcp/services/readme_generator.py
@@ -1,0 +1,229 @@
+"""README and quilt_summarize.json generation for packages.
+
+This module provides functions to automatically generate README.md and quilt_summarize.json
+files for Quilt packages based on package metadata, files, and user-provided information.
+
+Per user requirements:
+- README contents should be added as actual files in the package (not package metadata)
+- Every package should include a quilt_summarize.json file containing at least the README
+  and, if relevant, a visualization
+"""
+
+import json
+from datetime import datetime
+from typing import Any, Dict, List, Optional
+
+
+def generate_package_readme(
+    package_name: str,
+    s3_uris: List[str],
+    metadata: Optional[Dict[str, Any]] = None,
+    registry: Optional[str] = None,
+    organized_structure: Optional[Dict[str, List[Dict[str, Any]]]] = None,
+) -> str:
+    """Generate a comprehensive README.md for a package.
+
+    Args:
+        package_name: Name of the package (namespace/name format)
+        s3_uris: List of S3 URIs included in the package
+        metadata: Package metadata dictionary
+        registry: Target registry URL
+        organized_structure: Organized file structure (if using smart organization)
+
+    Returns:
+        README content as markdown string
+    """
+    metadata = metadata or {}
+    description = metadata.get("description", "")
+
+    # Extract namespace and name
+    parts = package_name.split("/", 1)
+    namespace = parts[0] if len(parts) > 1 else ""
+    name = parts[1] if len(parts) > 1 else package_name
+
+    readme_parts = []
+
+    # Header
+    readme_parts.append(f"# {package_name}")
+    readme_parts.append("")
+
+    # Description
+    if description:
+        readme_parts.append("## Overview")
+        readme_parts.append("")
+        readme_parts.append(description)
+        readme_parts.append("")
+
+    # Package Information
+    readme_parts.append("## Package Information")
+    readme_parts.append("")
+    readme_parts.append(f"- **Package Name:** `{package_name}`")
+    if namespace:
+        readme_parts.append(f"- **Namespace:** `{namespace}`")
+    if registry:
+        readme_parts.append(f"- **Registry:** `{registry}`")
+
+    # Add other metadata fields
+    metadata_fields = {
+        "version": "Version",
+        "license": "License",
+        "author": "Author",
+        "contact": "Contact",
+        "homepage": "Homepage",
+        "doi": "DOI",
+    }
+
+    for key, label in metadata_fields.items():
+        if key in metadata and metadata[key]:
+            readme_parts.append(f"- **{label}:** {metadata[key]}")
+
+    readme_parts.append("")
+
+    # File Contents
+    readme_parts.append("## Contents")
+    readme_parts.append("")
+
+    if organized_structure:
+        # Use organized structure if available
+        total_files = sum(len(objects) for objects in organized_structure.values())
+        readme_parts.append(f"This package contains {total_files} file(s) organized into folders:")
+        readme_parts.append("")
+
+        for folder, objects in sorted(organized_structure.items()):
+            folder_name = folder if folder else "root"
+            readme_parts.append(f"### {folder_name}/")
+            readme_parts.append("")
+            readme_parts.append(f"- {len(objects)} file(s)")
+            readme_parts.append("")
+    else:
+        # Simple file listing
+        readme_parts.append(f"This package contains {len(s3_uris)} file(s):")
+        readme_parts.append("")
+
+        # List first few files
+        display_limit = 10
+        for i, uri in enumerate(s3_uris[:display_limit]):
+            # Extract filename from S3 URI
+            filename = uri.split("/")[-1]
+            readme_parts.append(f"- `{filename}`")
+
+        if len(s3_uris) > display_limit:
+            readme_parts.append(f"- ... and {len(s3_uris) - display_limit} more files")
+        readme_parts.append("")
+
+    # Usage Examples
+    readme_parts.append("## Usage")
+    readme_parts.append("")
+    readme_parts.append("### Installation")
+    readme_parts.append("")
+    readme_parts.append("```bash")
+    readme_parts.append("pip install quilt3")
+    readme_parts.append("```")
+    readme_parts.append("")
+
+    readme_parts.append("### Loading the Package")
+    readme_parts.append("")
+    readme_parts.append("```python")
+    readme_parts.append("import quilt3 as q3")
+    readme_parts.append("")
+    readme_parts.append("# Browse the package")
+    if registry:
+        readme_parts.append(f"pkg = q3.Package.browse('{package_name}', registry='{registry}')")
+    else:
+        readme_parts.append(f"pkg = q3.Package.browse('{package_name}')")
+    readme_parts.append("")
+    readme_parts.append("# List package contents")
+    readme_parts.append("for key in pkg:")
+    readme_parts.append("    print(f'{key}: {pkg[key]}')")
+    readme_parts.append("```")
+    readme_parts.append("")
+
+    # Additional metadata sections
+    if "tags" in metadata and metadata["tags"]:
+        readme_parts.append("## Tags")
+        readme_parts.append("")
+        for tag in metadata["tags"]:
+            readme_parts.append(f"- {tag}")
+        readme_parts.append("")
+
+    # Citation
+    if "doi" in metadata or "citation" in metadata:
+        readme_parts.append("## Citation")
+        readme_parts.append("")
+        if "citation" in metadata:
+            readme_parts.append(metadata["citation"])
+            readme_parts.append("")
+        elif "doi" in metadata:
+            readme_parts.append(f"DOI: {metadata['doi']}")
+            readme_parts.append("")
+
+    # Footer
+    readme_parts.append("---")
+    readme_parts.append("")
+    readme_parts.append(f"*Package created: {datetime.now().strftime('%Y-%m-%d')}*")
+    readme_parts.append("")
+    readme_parts.append("Generated automatically by Quilt MCP Server")
+
+    return "\n".join(readme_parts)
+
+
+def generate_quilt_summarize(
+    package_name: str,
+    readme_content: str,
+    metadata: Optional[Dict[str, Any]] = None,
+    registry: Optional[str] = None,
+    s3_uris: Optional[List[str]] = None,
+) -> str:
+    """Generate a quilt_summarize.json file for a package.
+
+    This follows the Quilt summarization schema and includes:
+    - Package summary
+    - Full README content
+    - Package metadata
+    - Optional visualizations (images array)
+
+    Args:
+        package_name: Name of the package
+        readme_content: Full README.md content
+        metadata: Package metadata dictionary
+        registry: Target registry URL
+        s3_uris: List of S3 URIs in the package (for file count)
+
+    Returns:
+        quilt_summarize.json content as JSON string
+    """
+    metadata = metadata or {}
+
+    # Extract summary from description or generate one
+    description = metadata.get("description", "")
+    summary = description[:200] + "..." if len(description) > 200 else description
+
+    if not summary:
+        summary = f"Quilt package: {package_name}"
+
+    summary_data = {
+        "type": "package",
+        "summary": summary,
+        "readme": readme_content,
+        "metadata": {
+            "package_name": package_name,
+            "created": datetime.now().isoformat(),
+            "registry": registry or "default",
+            "file_count": len(s3_uris) if s3_uris else 0,
+        },
+        "images": [],  # Placeholder for future visualization support
+    }
+
+    # Add user-provided metadata
+    if metadata:
+        # Copy relevant metadata fields
+        for key in ["version", "license", "author", "tags", "doi", "homepage"]:
+            if key in metadata:
+                summary_data["metadata"][key] = metadata[key]
+
+        # Add all other metadata fields
+        for key, value in metadata.items():
+            if key not in summary_data["metadata"] and key not in ["description"]:
+                summary_data["metadata"][key] = value
+
+    return json.dumps(summary_data, indent=2, ensure_ascii=False)

--- a/tests/unit/test_package_readme_generation.py
+++ b/tests/unit/test_package_readme_generation.py
@@ -1,0 +1,387 @@
+"""BDD tests for automatic README.md and quilt_summarize.json generation in packages.
+
+These tests verify that package creation automatically includes:
+1. README.md file with comprehensive package documentation
+2. quilt_summarize.json file with package summary and metadata
+
+Per user requirements:
+- README contents should be added as actual files in the package (not package metadata)
+- Every package should include a quilt_summarize.json file containing at least the README
+  and, if relevant, a visualization
+"""
+
+import json
+from unittest.mock import Mock, patch
+
+import pytest
+
+from quilt_mcp.services.quilt_service import QuiltService
+
+
+class TestAutomaticREADMEGeneration:
+    """Test automatic README.md generation during package creation."""
+
+    def test_create_package_includes_readme_by_default(self):
+        """Given I create a package with files,
+        When the package is created,
+        Then README.md should be automatically added to the package."""
+        service = QuiltService()
+
+        mock_package = Mock()
+        mock_package.set = Mock()
+        mock_package.set_meta = Mock()
+        mock_package.push = Mock(return_value="test-hash-123")
+
+        with (
+            patch('quilt3.Package', return_value=mock_package),
+            patch('quilt_mcp.services.quilt_service.QuiltService._organize_s3_files_smart', return_value={}),
+            patch(
+                'quilt_mcp.services.quilt_service.QuiltService._normalize_registry', return_value="s3://test-bucket"
+            ),
+        ):
+            result = service.create_package_revision(
+                package_name="test/dataset",
+                s3_uris=["s3://source/data.csv"],
+                metadata={"description": "Test dataset"},
+                registry="s3://test-bucket",
+                message="Test message",
+            )
+
+            # Verify README.md was added to package
+            readme_calls = [call for call in mock_package.set.call_args_list if 'README.md' in str(call)]
+            assert len(readme_calls) > 0, "README.md should be added to package"
+
+            # Verify README.md content was generated
+            readme_call = readme_calls[0]
+            readme_content = readme_call[0][1]  # Second argument is the content
+            assert isinstance(readme_content, str)
+            assert "test/dataset" in readme_content
+            assert "Test dataset" in readme_content
+
+    def test_readme_contains_package_metadata(self):
+        """Given I create a package with metadata,
+        When README.md is generated,
+        Then it should contain package name, description, and metadata information."""
+        service = QuiltService()
+
+        mock_package = Mock()
+        mock_package.set = Mock()
+        mock_package.set_meta = Mock()
+        mock_package.push = Mock(return_value="test-hash-123")
+
+        test_metadata = {
+            "description": "Comprehensive test dataset",
+            "version": "1.0.0",
+            "license": "MIT",
+            "tags": ["test", "example"],
+        }
+
+        with (
+            patch('quilt3.Package', return_value=mock_package),
+            patch('quilt_mcp.services.quilt_service.QuiltService._organize_s3_files_smart', return_value={}),
+            patch(
+                'quilt_mcp.services.quilt_service.QuiltService._normalize_registry', return_value="s3://test-bucket"
+            ),
+        ):
+            result = service.create_package_revision(
+                package_name="test/comprehensive-dataset",
+                s3_uris=["s3://source/data.csv"],
+                metadata=test_metadata,
+                registry="s3://test-bucket",
+            )
+
+            # Find README.md call
+            readme_calls = [call for call in mock_package.set.call_args_list if 'README.md' in str(call)]
+            assert len(readme_calls) > 0
+            readme_content = readme_calls[0][0][1]
+
+            # Verify metadata is in README
+            assert "Comprehensive test dataset" in readme_content
+            assert "version" in readme_content.lower() or "1.0.0" in readme_content
+            assert "license" in readme_content.lower() or "MIT" in readme_content
+
+    def test_readme_contains_file_listing(self):
+        """Given I create a package with multiple files,
+        When README.md is generated,
+        Then it should contain a listing of all files in the package."""
+        service = QuiltService()
+
+        mock_package = Mock()
+        mock_package.set = Mock()
+        mock_package.set_meta = Mock()
+        mock_package.push = Mock(return_value="test-hash-123")
+
+        with (
+            patch('quilt3.Package', return_value=mock_package),
+            patch(
+                'quilt_mcp.services.quilt_service.QuiltService._organize_s3_files_smart',
+                return_value={
+                    "data": [
+                        {"Key": "file1.csv", "Size": 1000},
+                        {"Key": "file2.csv", "Size": 2000},
+                    ]
+                },
+            ),
+            patch(
+                'quilt_mcp.services.quilt_service.QuiltService._normalize_registry', return_value="s3://test-bucket"
+            ),
+        ):
+            result = service.create_package_revision(
+                package_name="test/multi-file",
+                s3_uris=["s3://source/file1.csv", "s3://source/file2.csv"],
+                metadata={"description": "Multi-file dataset"},
+                registry="s3://test-bucket",
+            )
+
+            # Find README.md call
+            readme_calls = [call for call in mock_package.set.call_args_list if 'README.md' in str(call)]
+            assert len(readme_calls) > 0
+            readme_content = readme_calls[0][0][1]
+
+            # Verify files are mentioned in README
+            assert "file1.csv" in readme_content or "file" in readme_content.lower()
+
+    def test_readme_contains_usage_examples(self):
+        """Given I create a package,
+        When README.md is generated,
+        Then it should contain Python code examples showing how to use the package."""
+        service = QuiltService()
+
+        mock_package = Mock()
+        mock_package.set = Mock()
+        mock_package.set_meta = Mock()
+        mock_package.push = Mock(return_value="test-hash-123")
+
+        with (
+            patch('quilt3.Package', return_value=mock_package),
+            patch('quilt_mcp.services.quilt_service.QuiltService._organize_s3_files_smart', return_value={}),
+            patch(
+                'quilt_mcp.services.quilt_service.QuiltService._normalize_registry', return_value="s3://test-bucket"
+            ),
+        ):
+            result = service.create_package_revision(
+                package_name="test/example-package",
+                s3_uris=["s3://source/data.csv"],
+                metadata={"description": "Example dataset"},
+                registry="s3://test-bucket",
+            )
+
+            # Find README.md call
+            readme_calls = [call for call in mock_package.set.call_args_list if 'README.md' in str(call)]
+            assert len(readme_calls) > 0
+            readme_content = readme_calls[0][0][1]
+
+            # Verify usage examples are present
+            assert "```python" in readme_content or "import" in readme_content
+            assert "quilt3" in readme_content.lower() or "package" in readme_content.lower()
+
+
+class TestAutomaticQuiltSummarizeGeneration:
+    """Test automatic quilt_summarize.json generation during package creation."""
+
+    def test_create_package_includes_quilt_summarize_by_default(self):
+        """Given I create a package with files,
+        When the package is created,
+        Then quilt_summarize.json should be automatically added to the package."""
+        service = QuiltService()
+
+        mock_package = Mock()
+        mock_package.set = Mock()
+        mock_package.set_meta = Mock()
+        mock_package.push = Mock(return_value="test-hash-123")
+
+        with (
+            patch('quilt3.Package', return_value=mock_package),
+            patch('quilt_mcp.services.quilt_service.QuiltService._organize_s3_files_smart', return_value={}),
+            patch(
+                'quilt_mcp.services.quilt_service.QuiltService._normalize_registry', return_value="s3://test-bucket"
+            ),
+        ):
+            result = service.create_package_revision(
+                package_name="test/dataset",
+                s3_uris=["s3://source/data.csv"],
+                metadata={"description": "Test dataset"},
+                registry="s3://test-bucket",
+            )
+
+            # Verify quilt_summarize.json was added to package
+            summary_calls = [call for call in mock_package.set.call_args_list if 'quilt_summarize.json' in str(call)]
+            assert len(summary_calls) > 0, "quilt_summarize.json should be added to package"
+
+            # Verify content is valid JSON
+            summary_call = summary_calls[0]
+            summary_content = summary_call[0][1]  # Second argument is the content
+            summary_data = json.loads(summary_content)
+            assert isinstance(summary_data, dict)
+
+    def test_quilt_summarize_contains_readme(self):
+        """Given I create a package,
+        When quilt_summarize.json is generated,
+        Then it should contain the full README content."""
+        service = QuiltService()
+
+        mock_package = Mock()
+        mock_package.set = Mock()
+        mock_package.set_meta = Mock()
+        mock_package.push = Mock(return_value="test-hash-123")
+
+        with (
+            patch('quilt3.Package', return_value=mock_package),
+            patch('quilt_mcp.services.quilt_service.QuiltService._organize_s3_files_smart', return_value={}),
+            patch(
+                'quilt_mcp.services.quilt_service.QuiltService._normalize_registry', return_value="s3://test-bucket"
+            ),
+        ):
+            result = service.create_package_revision(
+                package_name="test/dataset",
+                s3_uris=["s3://source/data.csv"],
+                metadata={"description": "Test dataset"},
+                registry="s3://test-bucket",
+            )
+
+            # Get README content
+            readme_calls = [call for call in mock_package.set.call_args_list if 'README.md' in str(call)]
+            readme_content = readme_calls[0][0][1]
+
+            # Get quilt_summarize.json content
+            summary_calls = [call for call in mock_package.set.call_args_list if 'quilt_summarize.json' in str(call)]
+            summary_content = summary_calls[0][0][1]
+            summary_data = json.loads(summary_content)
+
+            # Verify README is in summary
+            assert "readme" in summary_data
+            assert summary_data["readme"] == readme_content
+
+    def test_quilt_summarize_has_required_structure(self):
+        """Given I create a package,
+        When quilt_summarize.json is generated,
+        Then it should have the required structure with summary, metadata, and readme."""
+        service = QuiltService()
+
+        mock_package = Mock()
+        mock_package.set = Mock()
+        mock_package.set_meta = Mock()
+        mock_package.push = Mock(return_value="test-hash-123")
+
+        with (
+            patch('quilt3.Package', return_value=mock_package),
+            patch('quilt_mcp.services.quilt_service.QuiltService._organize_s3_files_smart', return_value={}),
+            patch(
+                'quilt_mcp.services.quilt_service.QuiltService._normalize_registry', return_value="s3://test-bucket"
+            ),
+        ):
+            result = service.create_package_revision(
+                package_name="test/dataset",
+                s3_uris=["s3://source/data.csv"],
+                metadata={"description": "Test dataset"},
+                registry="s3://test-bucket",
+            )
+
+            # Get quilt_summarize.json content
+            summary_calls = [call for call in mock_package.set.call_args_list if 'quilt_summarize.json' in str(call)]
+            summary_content = summary_calls[0][0][1]
+            summary_data = json.loads(summary_content)
+
+            # Verify required fields
+            assert "summary" in summary_data
+            assert "readme" in summary_data
+            assert "metadata" in summary_data
+            assert summary_data["metadata"]["package_name"] == "test/dataset"
+
+
+class TestConfigurableREADMEGeneration:
+    """Test configurable README and quilt_summarize.json generation."""
+
+    def test_can_disable_readme_generation(self):
+        """Given I create a package with include_readme=False,
+        When the package is created,
+        Then README.md should NOT be added to the package."""
+        service = QuiltService()
+
+        mock_package = Mock()
+        mock_package.set = Mock()
+        mock_package.set_meta = Mock()
+        mock_package.push = Mock(return_value="test-hash-123")
+
+        with (
+            patch('quilt3.Package', return_value=mock_package),
+            patch('quilt_mcp.services.quilt_service.QuiltService._organize_s3_files_smart', return_value={}),
+            patch(
+                'quilt_mcp.services.quilt_service.QuiltService._normalize_registry', return_value="s3://test-bucket"
+            ),
+        ):
+            result = service.create_package_revision(
+                package_name="test/dataset",
+                s3_uris=["s3://source/data.csv"],
+                metadata={"description": "Test dataset"},
+                registry="s3://test-bucket",
+                include_readme=False,
+            )
+
+            # Verify README.md was NOT added to package
+            readme_calls = [call for call in mock_package.set.call_args_list if 'README.md' in str(call)]
+            assert len(readme_calls) == 0, "README.md should not be added when include_readme=False"
+
+    def test_can_provide_custom_readme_content(self):
+        """Given I create a package with custom readme_content,
+        When the package is created,
+        Then the custom README content should be used instead of auto-generated."""
+        service = QuiltService()
+
+        mock_package = Mock()
+        mock_package.set = Mock()
+        mock_package.set_meta = Mock()
+        mock_package.push = Mock(return_value="test-hash-123")
+
+        custom_readme = "# Custom README\n\nThis is my custom README content."
+
+        with (
+            patch('quilt3.Package', return_value=mock_package),
+            patch('quilt_mcp.services.quilt_service.QuiltService._organize_s3_files_smart', return_value={}),
+            patch(
+                'quilt_mcp.services.quilt_service.QuiltService._normalize_registry', return_value="s3://test-bucket"
+            ),
+        ):
+            result = service.create_package_revision(
+                package_name="test/dataset",
+                s3_uris=["s3://source/data.csv"],
+                metadata={"description": "Test dataset"},
+                registry="s3://test-bucket",
+                readme_content=custom_readme,
+            )
+
+            # Verify custom README content was used
+            readme_calls = [call for call in mock_package.set.call_args_list if 'README.md' in str(call)]
+            assert len(readme_calls) > 0
+            readme_content = readme_calls[0][0][1]
+            assert readme_content == custom_readme
+
+    def test_can_disable_quilt_summarize_generation(self):
+        """Given I create a package with include_quilt_summary=False,
+        When the package is created,
+        Then quilt_summarize.json should NOT be added to the package."""
+        service = QuiltService()
+
+        mock_package = Mock()
+        mock_package.set = Mock()
+        mock_package.set_meta = Mock()
+        mock_package.push = Mock(return_value="test-hash-123")
+
+        with (
+            patch('quilt3.Package', return_value=mock_package),
+            patch('quilt_mcp.services.quilt_service.QuiltService._organize_s3_files_smart', return_value={}),
+            patch(
+                'quilt_mcp.services.quilt_service.QuiltService._normalize_registry', return_value="s3://test-bucket"
+            ),
+        ):
+            result = service.create_package_revision(
+                package_name="test/dataset",
+                s3_uris=["s3://source/data.csv"],
+                metadata={"description": "Test dataset"},
+                registry="s3://test-bucket",
+                include_quilt_summary=False,
+            )
+
+            # Verify quilt_summarize.json was NOT added to package
+            summary_calls = [call for call in mock_package.set.call_args_list if 'quilt_summarize.json' in str(call)]
+            assert len(summary_calls) == 0, "quilt_summarize.json should not be added when include_quilt_summary=False"


### PR DESCRIPTION
## Overview

Implements automatic generation of README.md and quilt_summarize.json files for all Quilt packages, addressing user requirements that:
- README contents should be added as actual files in the package (not package metadata)
- Every package should include a quilt_summarize.json file containing at least the README and, if relevant, visualizations

## Changes

### New Module: readme_generator.py
- ✅ `generate_package_readme()` - Creates comprehensive markdown README with:
  - Package name, description, and metadata
  - File contents listing (with smart organization support)
  - Usage examples with Python code
  - License, citation, and provenance information
- ✅ `generate_quilt_summarize()` - Creates JSON summary with:
  - Package summary and full README content
  - Complete metadata structure
  - Placeholder for future visualizations

### Updated: QuiltService.create_package_revision()
Added three new optional parameters:
- `include_readme: bool = True` - Automatically generate and include README.md
- `readme_content: Optional[str] = None` - Provide custom README content
- `include_quilt_summary: bool = True` - Automatically generate quilt_summarize.json

### Testing
- ✅ 10 new BDD tests in `test_package_readme_generation.py`
- ✅ All 268 unit tests pass
- ✅ 91% code coverage for readme_generator.py
- ✅ 82% code coverage maintained for quilt_service.py
- ✅ TDD workflow followed (Red → Green)
- ✅ All linting checks passed

## Implementation Details

**Default Behavior:**
- README.md and quilt_summarize.json are automatically added to every package
- Files are actual package entries (using `pkg.set()`), NOT S3 metadata
- Generation happens before package push

**Configurable:**
- Can disable README generation: `include_readme=False`
- Can provide custom README: `readme_content="# My README..."`
- Can disable quilt_summarize.json: `include_quilt_summary=False`

**Backward Compatible:**
- All parameters are optional with sensible defaults
- No breaking changes to existing API
- Existing packages and tools continue to work unchanged

## Impact on Package Creation Tools

All package creation tools that use `QuiltService.create_package_revision()` now automatically benefit from this feature:
- `package_create()`
- `package_create_enhanced()`
- `create_package_enhanced()`
- `package_create_from_s3()`
- `create_package()` (unified tool)

## Example Usage

**Default (automatic generation):**
```python
result = service.create_package_revision(
    package_name="user/dataset",
    s3_uris=["s3://bucket/data.csv"],
    metadata={"description": "My dataset"}
)
# Package includes: data.csv, README.md, quilt_summarize.json
```

**Custom README:**
```python
result = service.create_package_revision(
    package_name="user/dataset",
    s3_uris=["s3://bucket/data.csv"],
    readme_content="# Custom README\n\nMy documentation..."
)
```

**Disable generation:**
```python
result = service.create_package_revision(
    package_name="user/dataset",
    s3_uris=["s3://bucket/data.csv"],
    include_readme=False,
    include_quilt_summary=False
)
```

## Verification Checklist

- [x] All tests pass (268/268)
- [x] Code coverage maintained (91% for new code)
- [x] Linting passes
- [x] No breaking changes
- [x] TDD workflow followed
- [x] README and quilt_summarize.json are package entries (not metadata)
- [x] Feature enabled by default
- [x] Configurable via parameters
- [x] Comprehensive BDD test coverage

## References

- User requirement: Every package should include README.md as an actual file
- User requirement: Every package should include quilt_summarize.json with at least README and visualizations
- Follows TDD principles with Red → Green workflow
- BDD tests verify all behavioral requirements

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Automatically generates and adds README.md and quilt_summarize.json when creating packages, with options to customize or disable; includes comprehensive unit tests.
> 
> - **Service**:
>   - Updates `QuiltService.create_package_revision()` to:
>     - Add params: `include_readme`, `readme_content`, `include_quilt_summary`.
>     - Generate and add `README.md` via `generate_package_readme()`.
>     - Generate and add `quilt_summarize.json` via `generate_quilt_summarize()`.
> - **New Module**: `src/quilt_mcp/services/readme_generator.py`
>   - `generate_package_readme(...)` for README markdown.
>   - `generate_quilt_summarize(...)` for package summary JSON.
> - **Tests**:
>   - Adds `tests/unit/test_package_readme_generation.py` covering default inclusion, metadata/contents, usage examples, and configurable enable/disable/custom README.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 492cd58bf633390e7353d11c37708d6c17fc380f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->