### PR TITLE
feat: Add quilt-mcp-remote.sh for desktop client JWT authentication

### DIFF
--- a/scripts/quilt-mcp-remote.sh
+++ b/scripts/quilt-mcp-remote.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+# Wrapper script for mcp-remote that reads JWT from quilt3 auth store
+# Usage: quilt-mcp-remote.sh <MCP_URL> [additional mcp-remote args]
+
+set -e
+
+# Default to demo stack if MCP_URL not provided
+MCP_URL="${1:-https://demo.quiltdata.com/mcp}"
+shift 2>/dev/null || true
+
+# Quilt auth file location (macOS)
+QUILT_AUTH_FILE="${HOME}/Library/Application Support/Quilt/auth.json"
+
+# Linux alternative
+if [[ ! -f "$QUILT_AUTH_FILE" ]]; then
+    QUILT_AUTH_FILE="${HOME}/.local/share/Quilt/auth.json"
+fi
+
+if [[ ! -f "$QUILT_AUTH_FILE" ]]; then
+    echo "ERROR: Quilt auth file not found. Please run 'quilt3 login' first." >&2
+    exit 1
+fi
+
+# Extract registry URL from MCP URL (e.g., https://demo.quiltdata.com/mcp -> https://demo-registry.quiltdata.com)
+# Parse the domain from MCP URL
+DOMAIN=$(echo "$MCP_URL" | sed -E 's|https?://([^/]+).*|\1|')
+
+# Build possible registry URLs to check
+REGISTRY_URL="https://${DOMAIN/demo./demo-registry.}"
+REGISTRY_URL_ALT="https://${DOMAIN}-registry.${DOMAIN#*.}"
+
+# Read access token from auth.json
+# Try primary registry URL first, then alternatives
+ACCESS_TOKEN=$(python3 -c "
+import json
+import sys
+import os
+
+auth_file = os.path.expanduser('$QUILT_AUTH_FILE')
+try:
+    with open(auth_file) as f:
+        auth = json.load(f)
+    
+    # Try exact registry URL match
+    for registry_url in ['$REGISTRY_URL', '$REGISTRY_URL_ALT']:
+        if registry_url in auth:
+            print(auth[registry_url].get('access_token', ''))
+            sys.exit(0)
+    
+    # Fallback: try to find any matching domain
+    domain = '$DOMAIN'.replace('.quiltdata.com', '').replace('-', '')
+    for key, value in auth.items():
+        if domain in key.lower().replace('-', ''):
+            print(value.get('access_token', ''))
+            sys.exit(0)
+    
+    # Last resort: use first available token
+    for key, value in auth.items():
+        if 'access_token' in value:
+            print(value.get('access_token', ''))
+            sys.exit(0)
+    
+    print('', file=sys.stderr)
+    sys.exit(1)
+except Exception as e:
+    print(f'Error reading auth file: {e}', file=sys.stderr)
+    sys.exit(1)
+" 2>&1)
+
+if [[ -z "$ACCESS_TOKEN" ]]; then
+    echo "ERROR: Could not extract access token from $QUILT_AUTH_FILE" >&2
+    echo "Please run 'quilt3 login' for your Quilt stack." >&2
+    exit 1
+fi
+
+# Run mcp-remote with the authorization header
+exec npx -y mcp-remote "$MCP_URL" --header "Authorization:Bearer ${ACCESS_TOKEN}" "$@"


### PR DESCRIPTION
## Summary

Add a wrapper script that enables desktop MCP clients (Cursor, VS Code, Claude Desktop, etc.) to connect to remote Quilt MCP servers with proper JWT authentication.

## Problem

Desktop MCP clients need to authenticate to remote Quilt MCP servers, but they don't have access to the browser's OAuth flow. Users already have JWT tokens from `quilt3 login`, but there was no way to pass these to remote MCP connections.

## Solution

`scripts/quilt-mcp-remote.sh` - A wrapper script that:

1. **Reads JWT access token** from the `quilt3 login` auth store
   - macOS: `~/Library/Application Support/Quilt/auth.json`
   - Linux: `~/.local/share/Quilt/auth.json`

2. **Passes token to `mcp-remote`** via `Authorization: Bearer` header

3. **Graceful fallback** with helpful error messages if auth file not found

## Usage

```bash
# In Cursor/VS Code MCP config:
{
  "quilt-mcp-remote": {
    "command": "/path/to/quilt-mcp-server/scripts/quilt-mcp-remote.sh",
    "type": "stdio",
    "args": ["https://demo.quiltdata.com/mcp"]
  }
}
```

## Prerequisites

- User must run `quilt3 login <registry-url>` first
- `npx` must be available (for `mcp-remote` package)

## Test Plan

- [x] Script extracts JWT from macOS auth file
- [x] Script passes JWT via Authorization header
- [x] Connection to remote MCP server succeeds
- [x] Multi-user isolation verified (each user's JWT → separate credentials)

## Related

- Deployment PR #2161 - Enables MCP server on T4 stacks

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add a wrapper script that reads Quilt JWT from local auth and runs mcp-remote with an Authorization header, supporting macOS/Linux paths and registry URL fallbacks.
> 
> - **Scripts**:
>   - **New `scripts/quilt-mcp-remote.sh`**:
>     - Defaults `MCP_URL`, locates Quilt auth file on macOS/Linux.
>     - Derives registry URL(s) from MCP domain; extracts `access_token` from `auth.json` via Python with fallbacks.
>     - Runs `npx mcp-remote` with `Authorization:Bearer <token>` and clear error handling when auth/token missing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2ad0f3494f2062ccb4819fa1ebaa0333dde71fc1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->