### PR TITLE
fix: Replace files instead of creating duplicates in package_update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Package Update Behavior**: Fixed `package_update()` to correctly replace files instead of creating duplicates
+  - Previously, updating a package with a file at the same logical path would create numbered duplicates (e.g., `1_file.txt`, `2_file.txt`)
+  - Now correctly replaces the file at the same logical path, with the old version remaining accessible in package history
+  - This behavior aligns with Quilt's versioned package system - each push creates a new version with a unique top_hash
+  - Added warning message when a file is replaced during update
+  - Updated tests to verify replacement behavior instead of duplicate creation
+
 ## [0.9.4] - 2025-12-12
 
 ### Added

--- a/src/quilt_mcp/tools/packages.py
+++ b/src/quilt_mcp/tools/packages.py
@@ -99,11 +99,13 @@ def _collect_objects_into_package(
             warnings.append(f"Skipping URI that appears to be a 'directory': {uri}")
             continue
         logical_path = os.path.basename(key) if flatten else key
-        original_logical_path = logical_path
-        counter = 1
-        while logical_path in pkg:
-            logical_path = f"{counter}_{original_logical_path}"
-            counter += 1
+
+        # Since Quilt packages are versioned, we simply replace files at the same logical path
+        # The old file remains accessible in previous package versions
+        # No need for 1_filename, 2_filename collision avoidance
+        if logical_path in pkg:
+            warnings.append(f"Replacing existing file at logical path: {logical_path}")
+
         try:
             pkg.set(logical_path, uri)
             added.append({"logical_path": logical_path, "source": uri})


### PR DESCRIPTION
## Summary

Fixes the behavior where `package_update()` would create numbered duplicates (`1_file.txt`, `2_file.txt`) when updating files at the same logical path.

## Problem

The previous implementation treated Quilt packages as if they needed collision avoidance within a single version. When updating a package with a file that already existed at a logical path, it would:
- Keep the original file (e.g., `data.csv`)
- Add the new file with a numbered prefix (e.g., `1_data.csv`)
- Each subsequent update would increment the counter (e.g., `2_data.csv`, `3_data.csv`)

This behavior is **incorrect** because Quilt packages are **versioned** - each push creates a new version with a unique `top_hash`.

## Solution

Files at the same logical path now **replace** the existing file in the new version. The old file remains accessible in the previous package version through package history.

This aligns with how versioned package systems should work:
- ✅ Update replaces the file in the new version
- ✅ Old file is still accessible in previous versions
- ✅ No `1_file.txt`, `2_file.txt` duplicates

## Changes

- **Code**: Removed counter-based collision avoidance logic in `_collect_objects_into_package()`
- **Behavior**: Files at duplicate logical paths now replace the existing file
- **UX**: Added warning message when files are replaced during update
- **Tests**: Updated test expectations to verify replacement behavior instead of duplicate creation
- **Docs**: Updated CHANGELOG.md with fix details

## Testing

All existing tests pass, including:
- ✅ `test_collect_objects_with_duplicate_logical_paths` - Updated to verify replacement
- ✅ All package creation/update/delete tests
- ✅ Integration tests for package workflows

🤖 Generated with [Claude Code](https://claude.com/claude-code)