### PR TITLE
Revert "chore(deps): Update all major dependencies (major)" (#290)

### DIFF
--- a/.github/actions/coverage-report/action.yml
+++ b/.github/actions/coverage-report/action.yml
@@ -32,7 +32,7 @@ runs:
 
     - name: Upload coverage artifacts
       if: always()
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@v6
       with:
         name: coverage-analysis-py${{ inputs.python-version }}
         path: build/test-results/

--- a/.github/actions/create-release/action.yml
+++ b/.github/actions/create-release/action.yml
@@ -107,7 +107,7 @@ runs:
     - name: Create GitHub Release
       id: create-release
       if: ${{ startsWith(github.ref, 'refs/tags/') }}
-      uses: softprops/action-gh-release@v3
+      uses: softprops/action-gh-release@v2
       with:
         name: "quilt-mcp v${{ inputs.package-version }}"
         files: |
@@ -118,7 +118,7 @@ runs:
         generate_release_notes: true
 
     - name: Upload MCPB artifacts
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@v6
       with:
         name: mcpb-package
         path: dist/*.mcpb

--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -30,7 +30,7 @@ runs:
 
     - name: Upload test artifacts
       if: inputs.upload-artifacts == 'true' && always()
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@v6
       with:
         name: ${{ inputs.artifact-name }}-py${{ inputs.python-version }}
         path: build/test-results/

--- a/.github/actions/setup-build-env/action.yml
+++ b/.github/actions/setup-build-env/action.yml
@@ -18,7 +18,7 @@ runs:
   using: 'composite'
   steps:
     - name: Install uv
-      uses: astral-sh/setup-uv@v10.0.1
+      uses: astral-sh/setup-uv@v7
       with:
         version: "latest"
         
@@ -28,7 +28,7 @@ runs:
       
     - name: Set up Node.js
       if: inputs.include-nodejs == 'true'
-      uses: actions/setup-node@v7
+      uses: actions/setup-node@v6
       with:
         node-version: ${{ inputs.nodejs-version }}
       
@@ -38,7 +38,7 @@ runs:
       run: npm install -g @anthropic-ai/mcpb
       
     - name: Cache dependencies
-      uses: actions/cache@v6
+      uses: actions/cache@v5
       with:
         path: |
           ~/.cache/uv

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v7
+      uses: actions/checkout@v6
 
     - name: Setup build environment
       uses: ./.github/actions/setup-build-env
@@ -88,7 +88,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v7
+      uses: actions/checkout@v6
 
     - name: Setup build environment
       uses: ./.github/actions/setup-build-env

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -28,7 +28,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v7
+      uses: actions/checkout@v6
 
     - name: Setup build environment
       uses: ./.github/actions/setup-build-env
@@ -76,7 +76,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v7
+      uses: actions/checkout@v6
 
     - name: Setup build environment
       uses: ./.github/actions/setup-build-env

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,7 @@ exclude = ["shared", "scripts"]
 "" = "src"
 
 [build-system]
-requires = ["setuptools>=84,<84.1", "wheel"]
+requires = ["setuptools>=82,<82.1", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [dependency-groups]


### PR DESCRIPTION
Reverts #290 (merge commit 29410ac).

## Why

#290 was merged in error during a batch dependency-bot reconciliation. That batch was explicitly scoped to **exclude** major-version bumps, which were set aside for human judgment. The filter I used matched `from vN to vM` title patterns and missed the literal `(major)` in this PR's title, so it landed in the auto-merge set.

Reverting at the operator's direction, not because anything broke: `Main Branch Validation` on main was green after #290 (test 3.11/3.12/3.13 all passing). This restores the pre-#290 state so the majors can be evaluated deliberately.

## What this restores

| Dependency | #290 set | reverted to |
|---|---|---|
| actions/cache | v6 | v5 |
| actions/checkout | v7 | v6 |
| actions/setup-node | v7 | v6 |
| actions/upload-artifact | v7 | v6 |
| astral-sh/setup-uv | v10.0.1 | v7 |
| softprops/action-gh-release | v3 | v2 |
| setuptools | >=84,<84.1 | >=82,<82.1 |

All CI/build tooling — no runtime or library code. 7 files, 12 insertions / 12 deletions, a clean `git revert` with no conflicts.

## Follow-up

These majors are still worth taking, just deliberately. `astral-sh/setup-uv` v7 to v10 is a three-major jump and deserves its own look. Renovate will refile them individually or as a group; that PR should get a human review rather than a batch merge.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR cleanly reverts the accidental major dependency upgrade and restores the preceding CI and packaging-tool versions.
- Restores earlier major versions of six GitHub Actions dependencies across composite actions and workflows.
- Restores the setuptools build constraint from 84.x to 82.x.
- Makes no runtime application-code or workflow-input changes.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because it cleanly restores the previously used dependency configuration without changing workflow inputs or application behavior.

The changed files only reverse dependency-version updates, and the restored action and setuptools configurations match the repository’s preceding known configuration with no concrete incompatibility established.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| .github/actions/coverage-report/action.yml | Restores the prior upload-artifact major version without changing artifact configuration. |
| .github/actions/create-release/action.yml | Restores prior release and artifact action versions while preserving release inputs and behavior. |
| .github/actions/run-tests/action.yml | Restores the prior upload-artifact major version without changing test behavior. |
| .github/actions/setup-build-env/action.yml | Restores the prior setup-uv, setup-node, and cache versions with their existing inputs unchanged. |
| .github/workflows/pr.yml | Restores checkout v6 in both pull-request jobs. |
| .github/workflows/push.yml | Restores checkout v6 in both push and release jobs. |
| pyproject.toml | Restores the prior setuptools 82.x build-system constraint; current packaging configuration uses supported standard features. |

<sub>Reviews (1): Last reviewed commit: ["Revert &quot;chore(deps): Update all major de..."](https://github.com/quiltdata/quilt-mcp-server/commit/3ab2d5db2a690a757e01c2525592d234b9093016) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55764865)</sub>

<!-- /greptile_comment -->